### PR TITLE
feat: sanitize dynamic HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,6 +354,13 @@
              allStores.find(s => s.name.toUpperCase().includes(searchStr.toUpperCase()));
     };
 
+    const escapeHtml = str => String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
     const showStatus = (html, type = 'info') => {
       const alertClass = `alert-${type}`;
       const block = `<div class="simple-alert ${alertClass}">${html}</div>`;
@@ -427,18 +434,46 @@
 
     const updateStoreStatus = () => {
       updateStoreCounts();
-      $('storeStatusContainer').innerHTML = sortStoresNumerically(allStores)
-        .map(store => `
-          <div class="store-item">
-            <input type="checkbox" ${store.active ? 'checked' : ''} onchange="toggleStoreStatus('${store.code}', this.checked)"/>
-            <div class="info">
-              <span class="code">${store.code}</span>
-              <span class="name">${store.name}</span>
-              <span class="rank-badge rank-${store.rank.toLowerCase()}">${store.rank}</span>
-            </div>
-            <button class="remove-btn" onclick="removeStore('${store.code}')">×</button>
-          </div>`)
-        .join('');
+      const container = $('storeStatusContainer');
+      container.innerHTML = '';
+      sortStoresNumerically(allStores).forEach(store => {
+        const item = document.createElement('div');
+        item.className = 'store-item';
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = store.active;
+        checkbox.onchange = e => toggleStoreStatus(store.code, e.target.checked);
+        item.appendChild(checkbox);
+
+        const info = document.createElement('div');
+        info.className = 'info';
+
+        const codeSpan = document.createElement('span');
+        codeSpan.className = 'code';
+        codeSpan.textContent = store.code;
+        info.appendChild(codeSpan);
+
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'name';
+        nameSpan.textContent = store.name;
+        info.appendChild(nameSpan);
+
+        const rankSpan = document.createElement('span');
+        rankSpan.className = `rank-badge rank-${store.rank.toLowerCase()}`;
+        rankSpan.textContent = store.rank;
+        info.appendChild(rankSpan);
+
+        item.appendChild(info);
+
+        const removeBtn = document.createElement('button');
+        removeBtn.className = 'remove-btn';
+        removeBtn.onclick = () => removeStore(store.code);
+        removeBtn.textContent = '×';
+        item.appendChild(removeBtn);
+
+        container.appendChild(item);
+      });
       updateDistributeButtonState();
     };
 
@@ -503,14 +538,16 @@
             showSheetSelector();
           }
         } catch (err) {
-          $('fileStatus').innerHTML = `❌ Error reading file: ${err.message}`;
+          $('fileStatus').innerHTML = `❌ Error reading file: ${escapeHtml(err.message)}`;
         }
       };
       reader.readAsArrayBuffer(file);
     };
 
     const showSheetSelector = () => {
-      const options = currentWorkbook.SheetNames.map(name => `<option value="${name}">${name}</option>`).join('');
+      const options = currentWorkbook.SheetNames
+        .map(name => `<option value="${escapeHtml(name)}">${escapeHtml(name)}</option>`)
+        .join('');
       $('fileStatus').innerHTML = `
         <div style="margin: 10px 0;">
           <label style="display: block; margin-bottom: 5px; font-weight: 500;">Select Sheet to Import:</label>
@@ -578,7 +615,7 @@
           const store = findStoreByCodeOrName(storeIdentifier);
           if (!store) {
             skipped++;
-            errors.push(`Row ${idx + 1}: Store "${storeIdentifier}" not found`);
+            errors.push(`Row ${idx + 1}: Store "${escapeHtml(storeIdentifier)}" not found`);
             return;
           }
           
@@ -591,7 +628,7 @@
           imported++;
         });
 
-        let statusMsg = `✅ Imported ${imported} items from "${sheetName}"`;
+        let statusMsg = `✅ Imported ${imported} items from "${escapeHtml(sheetName)}"`;
         if (skipped > 0) {
           statusMsg += ` (${skipped} rows skipped)`;
           if (errors.length <= 5) {
@@ -602,43 +639,58 @@
         }
         
         $('fileStatus').innerHTML = statusMsg;
-        updateImportDisplay();
-      } catch (err) {
-        $('fileStatus').innerHTML = `❌ Import error: ${err.message}`;
-      }
-    };
+      updateImportDisplay();
+    } catch (err) {
+        $('fileStatus').innerHTML = `❌ Import error: ${escapeHtml(err.message)}`;
+    }
+  };
 
     const showColumnMapper = () => {
       const sheetName = $('sheetSelector').value;
       const rows = XLSX.utils.sheet_to_json(currentWorkbook.Sheets[sheetName], {header:1, defval:'', raw: false});
       if (rows.length === 0) return;
-      
+
       const previewRows = rows.slice(0, 5);
-      $('fileStatus').innerHTML = `
-        <div style="margin: 10px 0;">
-          <h4>Column Mapping for "${sheetName}"</h4>
-          <div style="background: #f5f5f5; padding: 8px; border-radius: 4px; margin: 8px 0; max-height: 150px; overflow: auto;">
-            <table style="width: 100%; font-size: 11px; border-collapse: collapse;">
-              ${previewRows.map((row, idx) => `
+      const previewHtml = previewRows.map((row, idx) => {
+        const cells = row.slice(0, 10).map((cell, colIdx) => {
+          const cellRaw = String(cell);
+          const cellTitle = escapeHtml(cellRaw);
+          const cellDisplay = escapeHtml(cellRaw.substring(0, 15));
+          return `<td style="padding: 2px 4px;" title="Column ${String.fromCharCode(65 + colIdx)}: ${cellTitle}">${cellDisplay}</td>`;
+        }).join('');
+        return `
                 <tr style="border-bottom: 1px solid #ddd;">
                   <td style="padding: 2px 4px; font-weight: bold; background: #eee;">${idx + 1}</td>
-                  ${row.slice(0, 10).map((cell, colIdx) => `
-                    <td style="padding: 2px 4px;" title="Column ${String.fromCharCode(65 + colIdx)}: ${String(cell)}">${String(cell).substring(0, 15)}</td>
-                  `).join('')}
-                </tr>
-              `).join('')}
-            </table>
-          </div>
-          <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin: 8px 0;">
-            ${['Item', 'Quantity', 'Store'].map((label, i) => `
+                  ${cells}
+                </tr>`;
+      }).join('');
+
+      const selectHtml = ['Item', 'Quantity', 'Store'].map((label, i) => {
+        const opts = rows[0].map((_, idx) => {
+          const headerRaw = String(rows[0][idx]);
+          const headerDisplay = escapeHtml(headerRaw.substring(0, 10));
+          return `<option value="${idx}" ${idx === i ? 'selected' : ''}>Column ${String.fromCharCode(65 + idx)} (${headerDisplay})</option>`;
+        }).join('');
+        return `
               <div>
                 <label style="font-size: 12px; font-weight: 500;">${label} Column:</label>
                 <select id="${['item', 'qty', 'store'][i]}ColSelect" style="width: 100%; padding: 4px;">
-                  ${rows[0].map((_, idx) => `<option value="${idx}" ${idx === i ? 'selected' : ''}>Column ${String.fromCharCode(65 + idx)} (${String(rows[0][idx]).substring(0, 10)})</option>`).join('')}
+                  ${opts}
                 </select>
                 ${i === 2 ? '<div style="font-size: 10px; color: #666; margin-top: 2px;">Accepts store codes or names</div>' : ''}
-              </div>
-            `).join('')}
+              </div>`;
+      }).join('');
+
+      $('fileStatus').innerHTML = `
+        <div style="margin: 10px 0;">
+          <h4>Column Mapping for "${escapeHtml(sheetName)}"</h4>
+          <div style="background: #f5f5f5; padding: 8px; border-radius: 4px; margin: 8px 0; max-height: 150px; overflow: auto;">
+            <table style="width: 100%; font-size: 11px; border-collapse: collapse;">
+              ${previewHtml}
+            </table>
+          </div>
+          <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin: 8px 0;">
+            ${selectHtml}
           </div>
           <div style="margin: 8px 0;">
             <label style="font-size: 12px; font-weight: 500;">Header Row (skip this many rows):</label>
@@ -719,21 +771,43 @@
         updateDistributeButtonState();
         return;
       }
-      
+
       clearBtn.classList.remove('hidden');
-      $('importContainer').innerHTML = itemsToSort.map((item, index) => {
+      const container = $('importContainer');
+      container.innerHTML = '';
+      itemsToSort.forEach((item, index) => {
         const store = allStores.find(s => s.code === item.storeCode);
         const status = !store ? 'NOT FOUND' : (store.active ? 'ACTIVE' : 'INACTIVE');
         const statusColor = !store ? '#e74c3c' : (store.active ? '#27ae60' : '#f39c12');
-        return `
-          <div class="queue-item">
-            <div>
-              <strong>${item.itemNumber}</strong> → ${item.storeCode}
-              <div class="details">Qty: ${item.quantity} | <span style="color:${statusColor};">${status}</span></div>
-            </div>
-            <button class="remove-btn" onclick="removeItem(${index})">×</button>
-          </div>`;
-      }).join('');
+
+        const qItem = document.createElement('div');
+        qItem.className = 'queue-item';
+
+        const info = document.createElement('div');
+        const strong = document.createElement('strong');
+        strong.textContent = item.itemNumber;
+        info.appendChild(strong);
+        info.appendChild(document.createTextNode(` → ${item.storeCode}`));
+
+        const details = document.createElement('div');
+        details.className = 'details';
+        details.textContent = `Qty: ${item.quantity} | `;
+        const statusSpan = document.createElement('span');
+        statusSpan.style.color = statusColor;
+        statusSpan.textContent = status;
+        details.appendChild(statusSpan);
+        info.appendChild(details);
+
+        qItem.appendChild(info);
+
+        const btn = document.createElement('button');
+        btn.className = 'remove-btn';
+        btn.onclick = () => removeItem(index);
+        btn.textContent = '×';
+        qItem.appendChild(btn);
+
+        container.appendChild(qItem);
+      });
       updateDistributeButtonState();
     };
 
@@ -948,6 +1022,13 @@
         $('issuesContainer').classList.remove('hidden');
         const totalIssueQty = issues.reduce((s,i) => s+i.quantity, 0);
         const hasInactive = issues.some(i => i.type === 'inactive');
+        const issueRows = issues.map(issue => `
+                    <tr>
+                      <td><strong>${escapeHtml(issue.itemNumber)}</strong></td>
+                      <td>${issue.quantity}</td>
+                      <td>${escapeHtml(issue.storeCode)}</td>
+                      <td style="color:${issue.type === 'not_found' ? 'var(--danger)' : 'var(--warning)'};">${escapeHtml(issue.message)}</td>
+                    </tr>`).join('');
 
         $('issuesContainer').innerHTML = `
           <div class="simple-alert alert-warning" style="margin-bottom:12px;">
@@ -962,13 +1043,7 @@
               <table class="store-pane-table">
                 <thead><tr><th>Item</th><th>Qty</th><th>Store Code</th><th>Issue</th></tr></thead>
                 <tbody>
-                  ${issues.map(issue => `
-                    <tr>
-                      <td><strong>${issue.itemNumber}</strong></td>
-                      <td>${issue.quantity}</td>
-                      <td>${issue.storeCode}</td>
-                      <td style="color:${issue.type === 'not_found' ? 'var(--danger)' : 'var(--warning)'};">${issue.message}</td>
-                    </tr>`).join('')}
+                  ${issueRows}
                 </tbody>
               </table>
               <div style="display:flex;justify-content:flex-end;margin-top:12px;">
@@ -985,54 +1060,60 @@
         $('issuesContainer').innerHTML = '';
       }
 
-      $('resultsContainer').innerHTML = `
-        <div class="simple-alert alert-info">
-          <strong>📦 Items Sorted by Store</strong> - ${validItems.length} items sorted to ${sortedStores.length} active stores
-          ${hasAnyDeltas ? `<div class="legend-note">Green tags/rows indicate units added by the <em>last redistribution</em>.</div>` : ''}
-        </div>
-        <div class="store-panes">
-          ${sortedStores.map(store => {
-            const itemsSorted = store.items.slice().sort((a,b) => a.itemNumber.localeCompare(b.itemNumber));
-            const storeDelta = itemsSorted.reduce((sum,it) => sum + (redistributionDeltas[`${it.itemNumber}|${store.storeCode}`] || 0), 0);
-            const isCollapsed = collapsedStores[store.storeCode];
-            const isCopied = copiedStores[store.storeCode];
+      const storeBlocks = sortedStores.map(store => {
+        const itemsSorted = store.items.slice().sort((a,b) => a.itemNumber.localeCompare(b.itemNumber));
+        const storeDelta = itemsSorted.reduce((sum,it) => sum + (redistributionDeltas[`${it.itemNumber}|${store.storeCode}`] || 0), 0);
+        const isCollapsed = collapsedStores[store.storeCode];
+        const isCopied = copiedStores[store.storeCode];
+        const storeCodeEsc = escapeHtml(store.storeCode);
+        const storeNameEsc = escapeHtml(store.storeName);
+        const rowsHtml = itemsSorted.map(it => {
+          const d = redistributionDeltas[`${it.itemNumber}|${store.storeCode}`] || 0;
+          const rowClass = d > 0 ? 'redistributed-row' : '';
+          const itemEsc = escapeHtml(it.itemNumber);
+          return `
+                        <tr class="${rowClass}">
+                          <td><strong>${itemEsc}</strong></td>
+                          <td>${it.quantity}${d>0 ? ` <span class="delta-badge">+${d}</span>` : ''}</td>
+                          <td>${storeCodeEsc}</td>
+                        </tr>`;
+        }).join('');
 
-            return `
+        return `
               <div class="store-pane ${isCollapsed ? 'collapsed' : ''}">
                 <div class="store-pane-header">
                   <div class="store-pane-title">
-                    <button class="collapse-toggle" onclick="toggleStoreCollapse('${store.storeCode}')" title="${isCollapsed ? 'Expand' : 'Collapse'}">
+                    <button class="collapse-toggle" onclick="toggleStoreCollapse('${storeCodeEsc}')" title="${isCollapsed ? 'Expand' : 'Collapse'}">
                       <span class="chev">▾</span> ${isCollapsed ? 'Expand' : 'Collapse'}
                     </button>
-                    ${store.storeCode} - ${store.storeName}
+                    ${storeCodeEsc} - ${storeNameEsc}
                     <span class="rank-badge rank-${store.rank.toLowerCase()}" style="margin-left:4px;background:rgba(255,255,255,0.2);">${store.rank}</span>
                     ${isCopied ? '<span class="copied-badge" title="Copied to clipboard">Copied</span>' : ''}
                   </div>
                   <div class="store-pane-stats">
                     ${store.totalQuantity} units total
                     ${storeDelta > 0 ? `<span class="delta-badge">+${storeDelta} redistributed</span>` : ''}
-                    <button class="copy-btn" title="Copy Item & Qty (Tab). Hold Alt for CSV" onclick="copyStoreItems('${store.storeCode}', event)">📋 Copy</button>
+                    <button class="copy-btn" title="Copy Item & Qty (Tab). Hold Alt for CSV" onclick="copyStoreItems('${storeCodeEsc}', event)">📋 Copy</button>
                   </div>
                 </div>
                 <div class="store-pane-body">
                   <table class="store-pane-table">
                     <thead><tr><th>Item</th><th>Qty</th><th>Code</th></tr></thead>
                     <tbody>
-                      ${itemsSorted.map(it => {
-                        const d = redistributionDeltas[`${it.itemNumber}|${store.storeCode}`] || 0;
-                        const rowClass = d > 0 ? 'redistributed-row' : '';
-                        return `
-                        <tr class="${rowClass}">
-                          <td><strong>${it.itemNumber}</strong></td>
-                          <td>${it.quantity}${d>0 ? ` <span class="delta-badge">+${d}</span>` : ''}</td>
-                          <td>${store.storeCode}</td>
-                        </tr>`;
-                      }).join('')}
+                      ${rowsHtml}
                     </tbody>
                   </table>
                 </div>
               </div>`;
-          }).join('')}
+      }).join('');
+
+      $('resultsContainer').innerHTML = `
+        <div class="simple-alert alert-info">
+          <strong>📦 Items Sorted by Store</strong> - ${validItems.length} items sorted to ${sortedStores.length} active stores
+          ${hasAnyDeltas ? `<div class="legend-note">Green tags/rows indicate units added by the <em>last redistribution</em>.</div>` : ''}
+        </div>
+        <div class="store-panes">
+          ${storeBlocks}
         </div>`;
       updateDistributeButtonState();
     };


### PR DESCRIPTION
## Summary
- add `escapeHtml` helper for encoding special characters
- rebuild store/status and import displays with DOM APIs
- escape user-supplied data throughout import and results rendering

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf490893c83269e6f101259292c7e